### PR TITLE
Fix short-term-load loading too many rows into RDS

### DIFF
--- a/short_term/load_short.py
+++ b/short_term/load_short.py
@@ -58,9 +58,9 @@ def upload_readings(tuples: list[tuple]):
         value_placeholders.append("( %s, %s, %s, %s, %s, %s )")
         values.extend(reading)  # Flatten the reading tuple
 
-        full_query = insert_query + ", ".join(value_placeholders) + ";"
+    full_query = insert_query + ", ".join(value_placeholders) + ";"
 
-        with get_connection() as conn:
-            cursor = conn.cursor()
-            cursor.execute(full_query, values)
-            conn.commit()
+    with get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute(full_query, values)
+        conn.commit()

--- a/short_term/test_load_short.py
+++ b/short_term/test_load_short.py
@@ -74,7 +74,7 @@ def test_upload_readings(mock_get_plant_ids, mock_get_connection):
 
     upload_readings(tuples)
 
-    assert mock_cursor.execute.call_count == 2
+    assert mock_cursor.execute.call_count == 1
 
     expected_query = """INSERT INTO beta.reading (plant_id, botanist_id,
     at, soil_moisture, temperature, last_watered) VALUES ( %s, %s, %s, %s, %s, %s )"""


### PR DESCRIPTION
The loading to RDS loading query was being executed inside the loop that appends more rows the the query string itself causing the duplication of data being inserted.

Simple fix by unindenting the code at the appropriate places.