### PR TITLE
Provision ec2 for dashbaord

### DIFF
--- a/dashboard/upload_dashboard.sh
+++ b/dashboard/upload_dashboard.sh
@@ -1,0 +1,26 @@
+source .env
+
+EC2_USER="ec2-user"
+DASHBOARD_DIR="~/dashboard"
+
+scp -i "$KEY_PATH" extract_dashboard.py load_dashboard.py transform_dashboard.py requirements.txt .env $EC2_USER@$EC2_HOST:$DASHBOARD_DIR/
+
+ssh -i "$KEY_PATH" $EC2_USER@$EC2_HOST << EOF
+    cd $DASHBOARD_DIR
+    
+    # Check if port 8501 is in use and kill any processes using it
+    if lsof -i :8501; then
+        echo "Killing processes using port 8501"
+        fuser -k 8501/tcp
+    else
+        echo "No processes are using port 8501"
+    fi
+    
+    # Create a Python virtual environment and install dependencies
+    python3 -m venv venv
+    source venv/bin/activate
+    pip install -r requirements.txt
+    
+    echo "Running Streamlit"
+    streamlit run load_dashboard.py --server.port 8501 --server.address 0.0.0.0
+EOF

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -4,4 +4,5 @@
 terraform.*
 .terraform.tfstate.lock.info
 *.pemkey
+*.pem
 *.env

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -335,6 +335,11 @@ resource "tls_private_key" "private_key" {
     rsa_bits = 4096
 }
 
+resource "local_file" "private_key_file" {
+    content  = tls_private_key.private_key.private_key_pem
+    filename = "${path.module}/c13-rvbyaulf-lmnh-key-pair.pem"
+}
+
 resource "aws_key_pair" "key_pair" {
     key_name = "c13-rvbyaulf-lmnh-key-pair"
     public_key = tls_private_key.private_key.public_key_openssh

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -327,3 +327,60 @@ resource "aws_scheduler_schedule" "long_term_etl_schedule" {
         }
     }
 }
+
+resource "tls_private_key" "private_key" {
+    algorithm = "RSA"
+    rsa_bits = 4096
+}
+
+resource "aws_key_pair" "key_pair" {
+    key_name = "c13-rvbyaulf-lmnh-key-pair"
+    public_key = tls_private_key.private_key.public_key_openssh
+}
+
+resource "aws_security_group" "ec2-sg" {
+    name = "c13-rvbyaulf-ec2-security-group"
+    vpc_id = data.aws_vpc.c13-vpc.id
+    ingress = [
+        {
+            from_port = 22
+            to_port = 22
+            protocol = "TCP"
+            cidr_blocks = ["0.0.0.0/0"]
+            description = "Allow ssh"
+            ipv6_cidr_blocks = []
+            prefix_list_ids = []
+            security_groups = []
+            self = false
+        }
+    ]
+    egress = [
+        {   
+            from_port = 0
+            to_port = 0
+            protocol = "-1"
+            cidr_blocks = ["0.0.0.0/0"]
+            description = "Allow all outbound"
+            ipv6_cidr_blocks = []
+            prefix_list_ids = []
+            security_groups = []
+            self = false
+        }
+    ]
+}
+
+resource "aws_instance" "pipeline_ec2" {
+    instance_type = "t3.nano"
+    tags = {Name: "c13-rvbyaulf-lmnh-plant-dashboard"}
+    security_groups = [aws_security_group.ec2-sg.id]
+    subnet_id = data.aws_subnet.c13-public-subnet.id
+    associate_public_ip_address = true
+    ami = "ami-0c0493bbac867d427"
+    key_name = aws_key_pair.key_pair.key_name
+    user_data = <<-EOF
+              #!/bin/bash
+              sudo yum update -y
+              sudo yum install -y python3
+              sudo yum install -y git
+              EOF
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -328,6 +328,8 @@ resource "aws_scheduler_schedule" "long_term_etl_schedule" {
     }
 }
 
+# =========================== LMNH Plant Dashboard ===========================
+
 resource "tls_private_key" "private_key" {
     algorithm = "RSA"
     rsa_bits = 4096
@@ -348,6 +350,28 @@ resource "aws_security_group" "ec2-sg" {
             protocol = "TCP"
             cidr_blocks = ["0.0.0.0/0"]
             description = "Allow ssh"
+            ipv6_cidr_blocks = []
+            prefix_list_ids = []
+            security_groups = []
+            self = false
+        },
+        {
+            from_port   = 8501
+            to_port     = 8501
+            protocol    = "tcp"
+            cidr_blocks = ["0.0.0.0/0"]
+            description = "Allow streamlit"
+            ipv6_cidr_blocks = []
+            prefix_list_ids = []
+            security_groups = []
+            self = false
+        },
+        {
+            from_port   = 80
+            to_port     = 80
+            protocol    = "tcp"
+            cidr_blocks = ["0.0.0.0/0"]
+            description = "Allow connection"
             ipv6_cidr_blocks = []
             prefix_list_ids = []
             security_groups = []
@@ -381,6 +405,5 @@ resource "aws_instance" "pipeline_ec2" {
               #!/bin/bash
               sudo yum update -y
               sudo yum install -y python3
-              sudo yum install -y git
               EOF
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -3,3 +3,11 @@
 output "etl_short_term_lambda_arn" {
     value = aws_lambda_function.lmnh_etl_short_term_lambda.arn
 }
+
+output "EC2_public_ip" {
+    value = aws_instance.pipeline_ec2.public_ip
+}
+
+output "EC2_public_dns" {
+    value = aws_instance.pipeline_ec2.public_dns
+}


### PR DESCRIPTION
The EC2 is now created using the Terraform files. To actually get the dashboard running however the scripts need to be moved across manually which can be done by taking the EC2 instance public dns or private IP, placing in a .env and then running the bash file dashboard/upload_dashboard.sh.